### PR TITLE
[ADD] add venv to gitignore list.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@
 
 # debug information files
 *.dwo
+
+# venvs
+*/.venv/


### PR DESCRIPTION
I prefer running the python tools in a (or multiple) separate venv's. Without this it clutters the workspace